### PR TITLE
Add support for LTeX-LS non-standard commands

### DIFF
--- a/lsp-ltex.el
+++ b/lsp-ltex.el
@@ -355,6 +355,28 @@ and concatenate them."
     res))
 
 ;;
+;; (@* "LTeX Special Commands")
+;;
+
+;; https://valentjn.github.io/ltex/ltex-ls/server-usage.html#_ltexcheckdocument-server
+(defun lsp-ltex-check-document ()
+  "Trigger the check of the current buffer/region."
+  (interactive)
+  (when-let ((file (buffer-file-name)))
+    (let* ((uri (lsp--path-to-uri file))
+           (beg (region-beginning))
+           (end (region-end))
+           (req (if (region-active-p)
+                    `(:uri ,uri
+                      :range ,(lsp--region-to-range beg end))
+                  `(:uri ,uri)))
+           (ret (lsp-send-execute-command "_ltex.checkDocument" req)))
+      (if (and ret (plist-get ret :success))
+          (message "Command executed successfully.")
+        (message "An error occured while executing the command: %s"
+                 (plist-get ret :errorMessage))))))
+
+;;
 ;; (@* "Installation and Upgrade" )
 ;;
 

--- a/lsp-ltex.el
+++ b/lsp-ltex.el
@@ -376,6 +376,11 @@ and concatenate them."
         (message "An error occured while executing the command: %s"
                  (plist-get ret :errorMessage))))))
 
+;; https://valentjn.github.io/ltex/ltex-ls/server-usage.html#_ltexgetserverstatus-server
+(defun lsp-ltex-get-server-status ()
+  "Get the server status."
+  (lsp-send-execute-command "_ltex.getServerStatus"))
+
 ;;
 ;; (@* "Installation and Upgrade" )
 ;;


### PR DESCRIPTION
## Background
There are two commands provided by LTeX-LS, [`_ltex.checkDocument`](https://valentjn.github.io/ltex/ltex-ls/server-usage.html#_ltexcheckdocument-server) and [`_ltex.getServerStatus`](https://valentjn.github.io/ltex/ltex-ls/server-usage.html#_ltexgetserverstatus-server). This adds an initial implementation of the two.

The idea of this draft is to try to fix an issue with the current `lsp-ltex`.

## The problem
I'm using `lsp-ltex` while writing Org files, I've noticed it to be too slow when editing big files, which is very annoying.

## An idea to mitigate this issue
I don't know much about how LSP mode works internally, even for `lsp-ltex`, I don't see how LSP figures out what command to call when requesting corrections for the document. However, the `_ltex.checkDocument` have an interesting feature (maybe, the same behavior can be achieved with other means) which allows requesting document checks for regions of the file.

Here is the interface to send to LTeX-LS when requesting the command execution of `_ltex.checkDocument`:

```typescript
interface CheckDocumentCommandParams {
  /**
   * URI of the document.
   */
  uri: string;

  /**
   * Code language ID of the document (e.g., `latex`). Will be determined by the file extension
   * of `uri` if missing.
   */
  codeLanguageId?: string;

  /**
   * Text to check. Will be determined as the contents of the file at `uri` if missing.
   */
  text?: string;

  /**
   * Range inside `text` (or the contents of the file at `uri` if missing) if only a part
   * of the document should be checked. Will be set to the range spanning all of `text` if missing.
   */
  range?: Range;
}

type CheckDocumentCommandResult = ServerCommandResult;
```

The idea is to leverage this to check the document incrementally, while typing, there is no interest to re-check the whole document if all we care about is the current paragraph! So we can send only the current paragraph (in the `:range` parameter) to avoid rechecking all the document even if it didn't change!

The current implementation for `lsp-ltex-check-document` allows checking a region (for now, it is implemented synchronously, which should be changed to an aync implementation later). However, after checking a region, I need to disable and enable `flycheck-mode` to see the wrong words (I don't know how to force `flycheck` to take new changes into account).

This is just an idea, discussions are welcome, note that I might be slow to respond these days!
