### PR TITLE
Handle AUCTeX's new mode naming convention

### DIFF
--- a/lsp-ltex.el
+++ b/lsp-ltex.el
@@ -50,7 +50,8 @@ https://github.com/valentjn/ltex-ls"
 
 (defcustom lsp-ltex-active-modes
   '( text-mode
-     bibtex-mode context-mode latex-mode
+     bibtex-mode context-mode
+     latex-mode LaTeX mode ;; AUCTeX 14+ has renamed latex-mode to LaTeX-mode
      markdown-mode org-mode
      rst-mode)
   "List of major mode that work with LTEX Language Server."


### PR DESCRIPTION
Hi, thanks for maintaining this package, it's great!

To quote this [other pull request ](https://github.com/ROCKTAKEY/lsp-latex/pull/44#issue-2135005829) :

>  Recently, AUCTeX renamed several of its major modes to avoid shadowing emacs built-in modes. This is documented here: https://git.savannah.gnu.org/cgit/auctex.git/tree/doc/changes.texi
> 
> As a result, if one has the newer version of AUCTeX (the version currently available from ELPA) then when they activate LaTeX-mode, lsp will be unavailable.

So I just added `LaTeX-mode` to the variable `lsp-ltex-active-modes` and it's working.

Also, I was wondering if we shouldn't add by default the other latex mode (i.e. `TeX-mode`, `tex-mode` and `yatex-mode`)